### PR TITLE
Resolves issue for boost sound

### DIFF
--- a/public/sketch.js
+++ b/public/sketch.js
@@ -18,6 +18,7 @@ let popups = [];
 
 function preload() {
   boostSound = loadSound('assets/sounds/boost.wav');
+  boostSound.setLoop(true);
   shotSound = loadSound('assets/sounds/shot.wav');
   explosionSound = loadSound('assets/sounds/explode1.wav');
   shotSound.setVolume(0.1)


### PR DESCRIPTION
When in excess of 200 units of shield was used for boost. The sound would stop, which was frustrating.

Added looping to ensure sound persists.